### PR TITLE
update at line 396

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -393,7 +393,7 @@ checkstyle_output <- function(lints, filename = "lintr_results.xml") {
           x$type),
         message = x$message,
                           
-		    linter_class = x$linter)
+        linter_class = x$linter)
     })
   })
 


### PR DESCRIPTION
- made changes at line 396 in the `checkstyle_output` function .

- This `linter` attribute should be added in the `checkstyle_output` XML format. 

- For configuring certain linters, we essentially need the name of the linter.

- Also, this would be similar to what pylint offers in its output which is convenient for disabling.

- I wanted to configure certain linters but was not able to get the name of the linters. 

- I  found them in the README link given on the CRAN page of the 'lintr' after searching a lot on the web. that was arduous.

- I got them locally when I converted the output of `lint` command to dataframe. 

- Hence, based on these I think that by adding the linter attribute in XML format will make it much easier for people in the future to know to which class the message belongs. 

- With this attribute in the XML format, it would be easy for people to know in which class a message belongs and can configure it. People would not have to then look on the internet to know the linter_class from which they got a message that they would like to configure.